### PR TITLE
feat/build_without_gpg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ First and foremost thanks to anyone who contributes, very much appreciated.
 ## Guidelines
 
 - If you add new faker classes like `Address`, `Country`, and `Number` they should be accompanied by a unit test.
-- New faker classes should be placed in the relevant group of providers. For example: `Minecraft` class will be in  the`videogame` group, `Address` in the `base` group.
+- New faker classes should be placed in the relevant group of providers. For example: `Minecraft` class will be in  the `videogame` group, `Address` in the `base` group.
 - If you add a new faker class, update the `README.md`.
 - Submit a PR with your change and if there are no comments, changes will be merged in.
 - If you're not sure about the change, raise an issue and have a discussion before spending time coding it up.
@@ -13,3 +13,6 @@ First and foremost thanks to anyone who contributes, very much appreciated.
 ## Building
 
 - Should be as easy as running `mvn clean install` on the root directory.
+- When you do not have [GnuPG](https://gnupg.org/) in your path, and you cannot install it, to be able to build without error you may
+  - specify the property `gpg.skip=true` when running maven, for example `mvn clean install '-Dgpg.skip=true'`.
+  - use the profile `noGpg`, for example `mvn clean install -PnoGpg`

--- a/pom.xml
+++ b/pom.xml
@@ -364,5 +364,19 @@
                 </pluginManagement>
             </build>
         </profile>
+        <profile>
+            <id>noGpg</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
When you cannot install GPG on the machine on which you want to contribute to datafaker, your build fails. By giving some details on how to manage this case in the documentation and by providing a maven profile, it can ease the process for newcomers to the project.