### PR TITLE
feat(adding_moves_to_pokemon_provider) (#448)

### DIFF
--- a/src/main/java/net/datafaker/providers/movie/Pokemon.java
+++ b/src/main/java/net/datafaker/providers/movie/Pokemon.java
@@ -18,4 +18,8 @@ public class Pokemon extends AbstractProvider<MovieProviders> {
     public String location() {
         return resolve("games.pokemon.locations");
     }
+
+    public String move() {
+        return resolve("games.pokemon.moves");
+    }
 }

--- a/src/test/java/net/datafaker/providers/movie/PokemonTest.java
+++ b/src/test/java/net/datafaker/providers/movie/PokemonTest.java
@@ -1,5 +1,6 @@
 package net.datafaker.providers.movie;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,4 +16,15 @@ class PokemonTest extends MovieFakerTest {
     void location() {
         assertThat(faker.pokemon().location()).matches("\\w+( \\w+)?( \\w+)?");
     }
+
+    @RepeatedTest(100)
+    void move() {
+        assertThat(faker.pokemon().move()).matches("[ \\-\\w+]+");
+    }
+
+    @RepeatedTest(100)
+    void move2() {
+        assertThat(faker.pokemon().move()).matches("\\w+(\\s|-)?(\\w+)?(\\s|-)?(\\w+)?");
+    }
+
 }


### PR DESCRIPTION
* feat(build_without_gpg)

When you cannot install GPG on the machine on which you want to contribute to datafaker, your build fails. By giving some details on how to manage this case in the documentation and by providing a maven profile, it can ease the process for newcomers to the project.

* feat(adding_moves_to_pokemon_provider)

The list of moves exists in the resource file but was not exploited in the pokemon provider. Small contribution to use it in order to provide a move generation in the provider.

* feat(adding_moves_to_pokemon_provider)

Adjusting the repetitions in the tests
